### PR TITLE
Fix ctypes.ArgumentError in Oodle decompression

### DIFF
--- a/src/pyuepak/oodle.py
+++ b/src/pyuepak/oodle.py
@@ -88,12 +88,41 @@ class Oodle:
 
         self.compress_fn = self.lib.OodleLZ_Compress
         self.compress_fn.restype = ctypes.c_longlong
+        self.compress_fn.argtypes = [
+            ctypes.c_int,           # compressor
+            ctypes.c_void_p,        # input buffer
+            ctypes.c_size_t,        # input length
+            ctypes.c_void_p,        # output buffer
+            ctypes.c_int,           # level
+            ctypes.c_void_p,        # config
+            ctypes.c_void_p,        # callback
+            ctypes.c_void_p,        # callback data
+            ctypes.c_void_p,        # decoder
+            ctypes.c_uint,          # decoder bytes
+        ]
 
         self.decompress_fn = self.lib.OodleLZ_Decompress
         self.decompress_fn.restype = ctypes.c_longlong
+        self.decompress_fn.argtypes = [
+            ctypes.c_void_p,        # input buffer
+            ctypes.c_size_t,        # input length
+            ctypes.c_void_p,        # output buffer
+            ctypes.c_size_t,        # output length
+            ctypes.c_int,           # decoder
+            ctypes.c_int,           # check
+            ctypes.c_int,           # verbose
+            ctypes.c_void_p,        # config
+            ctypes.c_size_t,        # config bytes
+            ctypes.c_void_p,        # callback
+            ctypes.c_void_p,        # callback data
+            ctypes.c_void_p,        # decoder
+            ctypes.c_size_t,        # decoder bytes
+            ctypes.c_int,           # thread
+        ]
 
         self.get_size_fn = self.lib.OodleLZ_GetCompressedBufferSizeNeeded
         self.get_size_fn.restype = ctypes.c_size_t
+        self.get_size_fn.argtypes = [ctypes.c_int, ctypes.c_size_t]
 
         # Disable Oodle's stdout logging
         self.set_printf = self.lib.OodleCore_Plugins_SetPrintf
@@ -126,8 +155,12 @@ class Oodle:
 
     def decompress(self, data: bytes, output_size: int) -> bytes:
         out_buffer = (ctypes.c_ubyte * output_size)()
+        # Convert bytearray to bytes for ctypes compatibility
+        if isinstance(data, bytearray):
+            data = bytes(data)
+        data_ptr = ctypes.c_char_p(data)
         written = self.decompress_fn(
-            data,
+            data_ptr,
             len(data),
             out_buffer,
             output_size,


### PR DESCRIPTION
# This PR use AI 

## Summary

Fix `ctypes.ArgumentError: argument 1: TypeError` when decompressing Oodle-compressed files from encrypted `.pak` archives.

## Problem

When reading Oodle-compressed files from encrypted `.pak` files (e.g., Unreal Engine games with AES encryption), the library crashes with:

```
ctypes.ArgumentError: argument 1: TypeError: Don't know how to convert parameter 1
```

### Root Cause

Two issues in `oodle.py`:

1. **Missing `argtypes`**: The ctypes function pointers (`OodleLZ_Compress`, `OodleLZ_Decompress`, `OodleLZ_GetCompressedBufferSizeNeeded`) did not have `argtypes` defined. Without type hints, ctypes cannot properly convert Python objects to C pointers.

2. **Type mismatch in `decompress()`**: The `data` parameter could be a `bytearray` (from `entry.py` line 272: `comp_block = data[r.start : r.stop]`), but `ctypes.c_char_p()` does not accept `bytearray` instances — only `bytes`.

## Changes

### 1. Added `argtypes` to all ctypes function pointers

```python
self.compress_fn.argtypes = [
    ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p,
    ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p,
    ctypes.c_void_p, ctypes.c_uint,
]

self.decompress_fn.argtypes = [
    ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p, ctypes.c_size_t,
    ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_void_p,
    ctypes.c_size_t, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p,
    ctypes.c_size_t, ctypes.c_int,
]

self.get_size_fn.argtypes = [ctypes.c_int, ctypes.c_size_t]
```

### 2. Fixed `decompress()` to handle `bytearray` input

```python
def decompress(self, data: bytes, output_size: int) -> bytes:
    out_buffer = (ctypes.c_ubyte * output_size)()
    # Convert bytearray to bytes for ctypes compatibility
    if isinstance(data, bytearray):
        data = bytes(data)
    data_ptr = ctypes.c_char_p(data)
    # ... rest of decompress
```

## Testing

Tested with game "Quarantine Zone The Last Check" (Steam AppID: 3419520):
- AES key extraction: ✅
- Pak file reading with Oodle decompression: ✅

## Files Changed

- `src/pyuepak/oodle.py` — Added `argtypes` and `bytearray` handling

## Notes

This fix is critical for any application that reads encrypted `.pak` files with Oodle compression, as the decryption process returns `bytearray` objects which were previously causing ctypes errors.

Game name : Quarantine Zone: The Last Check
AES Key: 0x776744ACA2357959907F48DFAB36E415C8CE8BCB2A0DF9CA874200CC196AC880
File : https://www.mediafire.com/file/4lqefl2zj85yvkr/pakchunk0-Windows.zip/file